### PR TITLE
Fix recursive directory traversal

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -114,7 +114,7 @@ function listDir(directoryId, localPath, isChildDir) {
         var files = [];
         _.each(data.files, function eachFile(fileNode) {
           if (fileNode.content_type == 'application/x-directory') {
-            listDir(fileNode.id, localFilePath, true);
+            listDir(fileNode.id, localPath, true);
           } else {
             files.push(fileNode);
           }


### PR DESCRIPTION
Paths were not passed correctly when recursively traversing directory tree. This correctly changes the path.